### PR TITLE
Optimization/Free tunning bug

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -4,6 +4,8 @@ local PlayerData = {}
 local lsMenuIsShowed = false
 local isInLSMarker = false
 local myCar = {}
+local isTunning = false
+local lastVehicle
 
 Citizen.CreateThread(function()
 	while ESX == nil do
@@ -55,6 +57,73 @@ AddEventHandler('esx_lscustom:cancelInstallMod', function()
 	if not (myCar.windowTint) then
 		SetVehicleWindowTint(vehicle, 0)
 	end
+end)
+
+Citizen.CreateThread(function()
+
+	while true do
+		Wait(0)
+		if isTunning then
+			local ped = PlayerPedId()
+			if IsPedInAnyVehicle(ped) then
+				local pedVeh = GetVehiclePedIsIn(ped,false)
+				if pedVeh ~= 0 then
+					if lastVehicle ~= pedVeh then
+						ESX.Game.SetVehicleProperties(lastVehicle, myCar)
+						if not (myCar.modTurbo) then
+							ToggleVehicleMod(lastVehicle,  18, false)
+						end
+						if not (myCar.modXenon) then
+							ToggleVehicleMod(lastVehicle,  22, false)
+						end
+						if not (myCar.windowTint) then
+							SetVehicleWindowTint(lastVehicle, 0)
+						end
+						lastVehicle = nil
+						myCar = {}
+						lsMenuIsShowed = false
+						FreezeEntityPosition(lastVehicle, false)
+						isTunning = false
+					end
+				else
+					ESX.Game.SetVehicleProperties(lastVehicle, myCar)
+					if not (myCar.modTurbo) then
+						ToggleVehicleMod(lastVehicle,  18, false)
+					end
+					if not (myCar.modXenon) then
+						ToggleVehicleMod(lastVehicle,  22, false)
+					end
+					if not (myCar.windowTint) then
+						SetVehicleWindowTint(lastVehicle, 0)
+					end
+					lastVehicle = nil
+					myCar = {}
+					lsMenuIsShowed = false
+					FreezeEntityPosition(lastVehicle, false)
+					isTunning = false
+				end
+			else
+				ESX.Game.SetVehicleProperties(lastVehicle, myCar)
+				if not (myCar.modTurbo) then
+					ToggleVehicleMod(lastVehicle,  18, false)
+				end
+				if not (myCar.modXenon) then
+					ToggleVehicleMod(lastVehicle,  22, false)
+				end
+				if not (myCar.windowTint) then
+					SetVehicleWindowTint(lastVehicle, 0)
+				end
+				lastVehicle = nil
+				myCar = {}
+				lsMenuIsShowed = false
+				FreezeEntityPosition(lastVehicle, false)
+				isTunning = false
+			end
+		else
+			Wait(500)
+		end
+	end
+
 end)
 
 function OpenLSMenu(elems, menuName, menuTitle, parent)
@@ -124,6 +193,7 @@ function OpenLSMenu(elems, menuName, menuTitle, parent)
 		if parent == nil then
 			lsMenuIsShowed = false
 			local vehicle = GetVehiclePedIsIn(PlayerPedId(), false)
+			isTunning = false
 			FreezeEntityPosition(vehicle, false)
 			myCar = {}
 		end
@@ -415,6 +485,8 @@ Citizen.CreateThread(function()
 					lsMenuIsShowed = true
 
 					local vehicle = GetVehiclePedIsIn(playerPed, false)
+					lastVehicle = vehicle
+					isTunning = true
 					FreezeEntityPosition(vehicle, true)
 
 					myCar = ESX.Game.GetVehicleProperties(vehicle)

--- a/client/main.lua
+++ b/client/main.lua
@@ -39,6 +39,7 @@ AddEventHandler('esx_lscustom:installMod', function()
 	local vehicle = GetVehiclePedIsIn(PlayerPedId(), false)
 	myCar = ESX.Game.GetVehicleProperties(vehicle)
 	TriggerServerEvent('esx_lscustom:refreshOwnedVehicle', myCar)
+	TriggerServerEvent('esx_lscustom:UpdateTunnedVehicles', myCar, vehicle)
 end)
 
 RegisterNetEvent('esx_lscustom:cancelInstallMod')
@@ -47,7 +48,9 @@ AddEventHandler('esx_lscustom:cancelInstallMod', function()
 	if (GetPedInVehicleSeat(vehicle, -1) ~= PlayerPedId()) then
 		 vehicle = GetPlayersLastVehicle(PlayerPedId())
 	end
-		ESX.Game.SetVehicleProperties(vehicle, myCar)
+
+	TriggerServerEvent('esx_lscustom:TunningDone')
+	ESX.Game.SetVehicleProperties(vehicle, myCar)
 	if not (myCar.modTurbo) then
 		ToggleVehicleMod(vehicle,  18, false)
 	end
@@ -228,6 +231,7 @@ function UpdateMods(data)
 
 		props[data.modType] = data.modNum
 		ESX.Game.SetVehicleProperties(vehicle, props)
+		TriggerServerEvent('esx_lscustom:UpdateTunnedVehicles', myCar, vehicle)
 	end
 end
 
@@ -490,7 +494,7 @@ Citizen.CreateThread(function()
 					FreezeEntityPosition(vehicle, true)
 
 					myCar = ESX.Game.GetVehicleProperties(vehicle)
-
+					TriggerServerEvent('esx_lscustom:UpdateTunnedVehicles', myCar, vehicle)
 					ESX.UI.Menu.CloseAll()
 					GetAction({value = 'main'})
 				end

--- a/client/main.lua
+++ b/client/main.lua
@@ -462,10 +462,34 @@ Citizen.CreateThread(function()
 	end
 end)
 
+local waitTime = 500
+local nearestCoords
+
+Citizen.CreateThread(function()
+
+    while true do
+        Wait(500)
+        if nearestCoords then
+            local ped = PlayerPedId()
+            local pedCoords = GetEntityCoords(ped)
+            if #(pedCoords - nearestCoords) > 20.5 then
+                nearestCoords = nil
+                waitTime = 500
+            else
+                Wait(500)
+            end
+        else
+            Wait(500)
+        end
+    end
+
+
+end)
+
 -- Activate menu when player is inside marker
 Citizen.CreateThread(function()
 	while true do
-		Citizen.Wait(0)
+		Citizen.Wait(waitTime)
 		local playerPed = PlayerPedId()
 
 		if IsPedInAnyVehicle(playerPed, false) then
@@ -476,6 +500,10 @@ Citizen.CreateThread(function()
 				for k,v in pairs(Config.Zones) do
 					if GetDistanceBetweenCoords(coords, v.Pos.x, v.Pos.y, v.Pos.z, true) < v.Size.x and not lsMenuIsShowed then
 						isInLSMarker  = true
+						if not nearestCoords then
+							waitTime = 0
+							nearestCoords = vector3(v.Pos.x, v.Pos.y, v.Pos.z)
+						end
 						ESX.ShowHelpNotification(v.Hint)
 						break
 					else

--- a/server/main.lua
+++ b/server/main.lua
@@ -1,4 +1,5 @@
 ESX = nil
+local playerTunning = {}
 local Vehicles
 
 TriggerEvent('esx:getSharedObject', function(obj) ESX = obj end)
@@ -34,6 +35,41 @@ AddEventHandler('esx_lscustom:buyMod', function(price)
 			TriggerClientEvent('esx:showNotification', _source, _U('not_enough_money'))
 		end
 	end
+end)
+
+RegisterNetEvent('esx_lscustom:UpdateTunnedVehicles')
+AddEventHandler('esx_lscustom:UpdateTunnedVehicles', function(props, vehicle)
+	local _source = source
+
+	playerTunning[_source] = {
+		vehicleProps = props,
+		vehicleId = vehicle
+	}
+
+end)
+
+RegisterNetEvent('esx_lscustom:TunningDone')
+AddEventHandler('esx_lscustom:TunningDone', function()
+	local _source = source
+
+	if playerTunning[_source] then
+		playerTunning[_source] = nil
+	end
+
+end)
+
+AddEventHandler('playerDropped', function (reason)
+	local _source = source
+
+	if playerTunning[_source] then
+		if DoesEntityExist(playerTunning[_source].vehicleId) then
+			if NetworkGetEntityOwner(playerTunning[_source].vehicleId) > 0 then
+				TriggerClientEvent('esx_lscustom:revertVehicleProperties', NetworkGetEntityOwner(playerTunning[_source].vehicleId), playerTunning[_source].vehicleProps)
+			end
+		end
+		playerTunning[_source] = nil
+	end
+
 end)
 
 RegisterServerEvent('esx_lscustom:refreshOwnedVehicle')


### PR DESCRIPTION
IN 3 commits, there are fixed 2 ways for getting free tunning, and in one of them, there is some optimization. One the bug was that when you leave the vehicle somehow (using /carry or something ...) then you get free tunning and the second when chose your tunning and you drop from the game (disconnect) the tunning will not despawn. All should be fixed and some little optimization.